### PR TITLE
update revancify.md (Termux-monet link)

### DIFF
--- a/docs/revancify.md
+++ b/docs/revancify.md
@@ -7,7 +7,7 @@ Revancify is a tool for building ReVanced in Termux. It is developed by [@deciph
 Installing Revancify for the first time
 =
 
-1. Install Termux. [Termux Monet](https://github.com/HardcodedCat/termux-monet/releases/latest) is recommended. Otherwise, use [Termux](https://github.com/termux/termux-app/releases/latest).
+1. Install Termux. [Termux Monet](https://github.com/Termux-Monet/termux-monet/releases) is recommended. Otherwise, use [Termux](https://github.com/termux/termux-app/releases/latest).
 
 2. Open Termux and run this command to install Revancify:
 


### PR DESCRIPTION
the Termux-monet repo(HardcodedCat/Termux-monet) linked to in this docs has been discontinued/deleted

change to Termux-Monet/termux-monet (archived repo)